### PR TITLE
Use HTTPS rather than HTTP when updating server

### DIFF
--- a/ipUpdate.py
+++ b/ipUpdate.py
@@ -37,7 +37,7 @@ except IOError:
 # pidfile=pidfile (default=/run/ipUpdate.pid)
 # logfile=logfile (default=/var/log/dnsexit.log)
 # cachefile=cachefile (default=/tmp/dnsexit-ip.txt)
-# url==http://update.dnsexit.com/RemoteUpdate.sv
+# url==https://update.dnsexit.com/RemoteUpdate.sv
 #
 ###################################################
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ proxyservs = "ip.dnsexit.com;ip2.dnsexit.com;ip3.dnsexit.com"
 logfile = "/var/log/dnsexit.log"
 cachefile = "/tmp/dnsexit-ip.txt"
 pidfile = "/run/ipUpdate.pid"
-siteurl = "http://update.dnsexit.com"
+siteurl = "https://update.dnsexit.com"
 geturlfrom = siteurl + "/ipupdate/dyndata.txt"
 
 URL_VALIDATE = siteurl + "/ipupdate/account_validate.jsp"


### PR DESCRIPTION
The client is currently sending the user's password in plaintext. There is no reason to do this; the server supports HTTPS. 